### PR TITLE
Fix a test

### DIFF
--- a/miniKanren-version/naive/nbe-untagged-full-tests.scm
+++ b/miniKanren-version/naive/nbe-untagged-full-tests.scm
@@ -1404,7 +1404,7 @@
 
 (test "evalo-free-var-2"
   (run* (val)
-    (eval-expro 'x val))
+    (evalo 'x val))
   '())
 
 (test "unevalo-free-var-1"


### PR DESCRIPTION
Looks like this should be `evalo` not `eval-expro`? That does make it the same as the previous test, though. Or something else is wrong with this test.